### PR TITLE
Fix Composer install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is designed to be an easy way in php to use the reviews API from trip advis
 
 This can be installed using composer for example
 
-    composer require exussum12\trip-advisor
+    composer require exussum12/trip-advisor
     
  Then the most simple method of getting the reviews is as follows
  


### PR DESCRIPTION
Package names have a forward slash instead of a backslash